### PR TITLE
Improve dynamo exception to catch that the table doesnt exists

### DIFF
--- a/persistence/dynamostore.py
+++ b/persistence/dynamostore.py
@@ -16,7 +16,7 @@ class DynamoStore:
         try:
             self.table.table_status in (
                 "CREATING", "UPDATING", "DELETING", "ACTIVE")
-        except ClientError:
+        except self.dynamo.meta.client.exceptions.ResourceNotFoundException:
             self.Logger.info(f'DynamoDB table {table_name} doesn\'t exist,'
                              'creating...')
             self.dynamo.create_table(


### PR DESCRIPTION
I've got an exception while the table doesn't exist. The default ClienError exception is not suitable to manage with the error correctly, so I changed it. 
@aprotsik , @nikolai-riabinin-epam , @NikopolosHub , @AliaksandrMakavetskiTR could you please review? 